### PR TITLE
fix(ssl untrusted cert): throw more helpful error when SSL cert is un…

### DIFF
--- a/Sources/IBMSwiftSDKCore/RestError.swift
+++ b/Sources/IBMSwiftSDKCore/RestError.swift
@@ -47,6 +47,9 @@ public enum RestError {
     
     /// The service URL was nil
     case noEndpoint
+    
+    /// The SSL certificate was untrusted
+    case sslCertificateUntrusted
 
     /// Generic HTTP error with a status code and description.
     case http(statusCode: Int?, message: String?, metadata: [String: Any]?)
@@ -75,6 +78,12 @@ extension RestError: LocalizedError {
             return "Malformed URL"
         case .noEndpoint:
             return "No service URL was provided."
+        case .sslCertificateUntrusted:
+            #if os(Linux)
+            return "If you're trying to call a service on ICP or Cloud Pak for Data, you may not have a valid SSL certificate. Please ensure that you have a valid certificate to make successful requests."
+            #else
+            return "If you're trying to call a service on ICP or Cloud Pak for Data, you may not have a valid SSL certificate. If you need to access the service without setting that up, try using the disableSSLVerification option in your authentication configuration and/or calling the disableSSLVerification() method on your service."
+            #endif
         case .http(_, let message, _):
             return message
         case .other(let message, _):

--- a/Sources/IBMSwiftSDKCore/RestRequest.swift
+++ b/Sources/IBMSwiftSDKCore/RestRequest.swift
@@ -107,6 +107,15 @@ extension RestRequest {
             // create a task to execute the request
             let task = self.session.dataTask(with: urlRequest) { (data, response, error) in
 
+                // handle SSL untrusted errors prior to any HTTP handling
+                // as these errors are NSErrors where repsonse is nil
+                if let error = error as NSError? {
+                    if error.code == NSURLErrorServerCertificateUntrusted {
+                        completionHandler(nil, nil, RestError.sslCertificateUntrusted)
+                        return
+                    }
+                }
+                
                 // ensure there is a valid http response
                 guard let response = response as? HTTPURLResponse else {
                     let error = RestError.noResponse


### PR DESCRIPTION
### Summary

Currently, if the server returns an error that the SSL certificate is untrusted, we get an archaic NSError and a response of `nil`. This causes the core to return a `RestError.noResponse` to the user, which masks the real issue. This adds better checking and handling for SSL cert errors, and returns a user friendly error.