### PR TITLE
Improve design for token refresh

### DIFF
--- a/Sources/IBMSwiftSDKCore/Authentication/Authentication.swift
+++ b/Sources/IBMSwiftSDKCore/Authentication/Authentication.swift
@@ -127,6 +127,9 @@ public protocol TokenSource {
      */
     var headers: [String: String]? {get set}
 
+    // Declare session to allow unit tests to insert mocks
+    var session: URLSession {get set}
+
     #if !os(Linux)
     /**
      Allow network requests to a server without verification of the server certificate.


### PR DESCRIPTION
This PR improves the design for token refresh by decoupling the refresh logic from active requests.

API requests use the most recent token available, but a refresh request is initiated whenever we are within the "refresh interval".  The refreshDate is updated whenever a refresh request is initiated to avoid a flood of refresh requests, potentially triggering a rate limit by the token source.