### PR TITLE
Add tests for generated Swift initializer methods

### DIFF
--- a/IBMSwiftSDKCore.xcodeproj/project.pbxproj
+++ b/IBMSwiftSDKCore.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 /* Begin PBXBuildFile section */
 		7E25A8D42331490800D3FB48 /* CredentialUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E25A8D32331490800D3FB48 /* CredentialUtils.swift */; };
 		7E25A8DC23314B3B00D3FB48 /* Resources in Resources */ = {isa = PBXBuildFile; fileRef = 7E25A8DA23314A5200D3FB48 /* Resources */; };
+		CA5CB0C2242666DE00243BBD /* SDKInitializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5CB0C02426667200243BBD /* SDKInitializerTests.swift */; };
 		OBJ_47 /* Authentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* Authentication.swift */; };
 		OBJ_48 /* CloudPakForDataAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* CloudPakForDataAuthenticator.swift */; };
 		OBJ_49 /* ConfigBasedAuthenticatorFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* ConfigBasedAuthenticatorFactory.swift */; };
@@ -69,6 +70,7 @@
 		7E25A8D32331490800D3FB48 /* CredentialUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CredentialUtils.swift; sourceTree = "<group>"; };
 		7E25A8D923314A5200D3FB48 /* Supporting Files */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "Supporting Files"; path = "Tests/Supporting Files"; sourceTree = "<group>"; };
 		7E25A8DA23314A5200D3FB48 /* Resources */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Resources; path = Tests/Resources; sourceTree = "<group>"; };
+		CA5CB0C02426667200243BBD /* SDKInitializerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKInitializerTests.swift; sourceTree = "<group>"; };
 		"IBMSwiftSDKCore::IBMSwiftSDKCore::Product" /* IBMSwiftSDKCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = IBMSwiftSDKCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"IBMSwiftSDKCore::IBMSwiftSDKCoreTests::Product" /* IBMSwiftSDKCoreTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = IBMSwiftSDKCoreTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		OBJ_10 /* Authentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Authentication.swift; sourceTree = "<group>"; };
@@ -142,6 +144,7 @@
 				OBJ_30 /* MultiPartFormDataTests.swift */,
 				OBJ_31 /* ResponseTests.swift */,
 				OBJ_32 /* RestErrorTests.swift */,
+				CA5CB0C02426667200243BBD /* SDKInitializerTests.swift */,
 			);
 			name = IBMSwiftSDKCoreTests;
 			path = Tests/IBMSwiftSDKCoreTests;
@@ -340,6 +343,7 @@
 				OBJ_78 /* ConfigBasedAuthenticatorFactoryTests-Linux.swift in Sources */,
 				OBJ_79 /* CredentialUtilsTests-Linux.swift in Sources */,
 				OBJ_80 /* JSONTests.swift in Sources */,
+				CA5CB0C2242666DE00243BBD /* SDKInitializerTests.swift in Sources */,
 				OBJ_81 /* MockURLProtocol.swift in Sources */,
 				OBJ_82 /* MultiPartFormDataTests.swift in Sources */,
 				OBJ_83 /* ResponseTests.swift in Sources */,

--- a/Scripts/generate-binaries.sh
+++ b/Scripts/generate-binaries.sh
@@ -6,6 +6,5 @@ popd > /dev/null
 cd $root
 cd ..
 
-carthage bootstrap
 carthage build --no-skip-current
 carthage archive --output IBMSwiftSDKCore.framework.zip

--- a/Tests/IBMSwiftSDKCoreTests/SDKInitializerTests.swift
+++ b/Tests/IBMSwiftSDKCoreTests/SDKInitializerTests.swift
@@ -1,0 +1,222 @@
+/**
+* Copyright IBM Corporation 2020
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
+
+import Foundation
+
+import XCTest
+@testable import IBMSwiftSDKCore
+
+class SDKInitializerTests: XCTestCase {
+
+    #if os(Linux)
+    static var allTests = [
+        ("testSomeSDKInit", testSomeSDKInit),
+        ("testSomeSDKNewInstance", testSomeSDKNewInstance),
+        ("testSomeSDKNewInstanceWithAuthenticator", testSomeSDKNewInstanceWithAuthenticator),
+        ("testSomeSDKNewInstanceWithServiceName", testSomeSDKNewInstanceWithServiceName),
+        ("testAnotherSDKInit", testAnotherSDKInit),
+        ("testAnotherSDKInitWithAuthenticator", testAnotherSDKInitWithAuthenticator),
+        ("testAnotherSDKInitWithServiceName", testAnotherSDKInitWithServiceName),
+    ]
+    #endif
+
+    // MARK: SDK Initializer methods
+
+    public class Shared {
+        public static let userAgent = "this is the user agent string"
+    }
+
+    // SomeSDK is the code generated for a service that does not specify `includeExternalConfig = true`
+    public class SomeSDK {
+        public var serviceURL: String? = "http://cloud.ibm.com/somesdk/v1"
+        public static let defaultServiceName = "service1"
+
+        public let authenticator: Authenticator
+
+        #if os(Linux)
+        class public func newInstance(authenticator: Authenticator? = nil, serviceName: String = defaultServiceName) throws -> SomeSDK {
+            let theAuthenticator = try authenticator ?? ConfigBasedAuthenticatorFactory.getAuthenticator(credentialPrefix: serviceName)
+            let myInstance = SomeSDK.init(authenticator: theAuthenticator)
+            if let serviceURL = CredentialUtils.getServiceURL(credentialPrefix: serviceName) {
+                myInstance.serviceURL = serviceURL
+            }
+            return myInstance
+        }
+        #endif
+
+        /**
+          Create a `SomeSDK` object.
+
+          - parameter authenticator: The Authenticator object used to authenticate requests to the service
+          */
+         public init(authenticator: Authenticator) {
+             self.authenticator = authenticator
+             RestRequest.userAgent = Shared.userAgent
+         }
+    }
+
+    // AnotherSDK is the code generated for a service that specifies `includeExternalConfig = true`
+    public class AnotherSDK {
+        public var serviceURL: String? = "http://cloud.ibm.com/anothersdk/v1"
+        public static let defaultServiceName = "service1"
+
+        public let authenticator: Authenticator
+
+        #if os(Linux)
+        public init(authenticator: Authenticator? = nil, serviceName: String = defaultServiceName) throws {
+            self.authenticator = try authenticator ?? ConfigBasedAuthenticatorFactory.getAuthenticator(credentialPrefix: serviceName)
+            if let serviceURL = CredentialUtils.getServiceURL(credentialPrefix: serviceName) {
+                self.serviceURL = serviceURL
+            }
+            RestRequest.userAgent = Shared.userAgent
+        }
+        #else
+        public init(authenticator: Authenticator) {
+            self.authenticator = authenticator
+            RestRequest.userAgent = Shared.userAgent
+        }
+        #endif
+    }
+
+    // MARK: includeExternalConfig disabled
+
+    // Test SDK initializers for a service that does not specify `includeExternalConfig = true`
+
+    // Test normal init method
+    func testSomeSDKInit() {
+        let authenticator = BasicAuthenticator(username: "username", password: "password")
+        let somesdk = SomeSDK(authenticator: authenticator)
+        XCTAssertNotNil(somesdk)
+        XCTAssertNotNil(somesdk.authenticator as? BasicAuthenticator)
+        XCTAssert(somesdk.serviceURL == "http://cloud.ibm.com/somesdk/v1")
+    }
+
+    #if os(Linux)
+    // Test NewInstance method without supplied authenticator
+    func testSomeSDKNewInstance() {
+        if ProcessInfo.processInfo.environment["VCAP_SERVICES"] == nil {
+            XCTFail("VCAP_SERVICES is not defined in the test environment")
+        }
+
+        do {
+            let somesdk = try SomeSDK.newInstance()
+            XCTAssertNotNil(somesdk)
+            XCTAssertNotNil(somesdk.authenticator as? BasicAuthenticator)
+            XCTAssertNotNil(somesdk.serviceURL == "https://myhost.com/my/service1/base/url") // from TestVcapServices.json
+        } catch {
+            XCTFail("newInstance method failed: \(error)")
+        }
+    }
+
+    // Test NewInstance method with supplied authenticator
+    func testSomeSDKNewInstanceWithAuthenticator() {
+        if ProcessInfo.processInfo.environment["VCAP_SERVICES"] == nil {
+            XCTFail("VCAP_SERVICES is not defined in the test environment")
+        }
+
+        do {
+            let authenticator = IAMAuthenticator(apiKey: "apikey")
+            let somesdk = try SomeSDK.newInstance(authenticator: authenticator)
+            XCTAssertNotNil(somesdk)
+            XCTAssertNotNil(somesdk.authenticator as? IAMAuthenticator)
+            XCTAssertNotNil(somesdk.serviceURL == "https://myhost.com/my/service1/base/url") // from TestVcapServices.json
+        } catch {
+            XCTFail("newInstance method failed: \(error)")
+        }
+    }
+
+    // Test NewInstance method with specified service name
+    func testSomeSDKNewInstanceWithServiceName() {
+        if ProcessInfo.processInfo.environment["VCAP_SERVICES"] == nil {
+            XCTFail("VCAP_SERVICES is not defined in the test environment")
+        }
+
+        do {
+            let somesdk = try SomeSDK.newInstance(serviceName: "service2")
+            XCTAssertNotNil(somesdk)
+            XCTAssertNotNil(somesdk.authenticator as? IAMAuthenticator)
+            XCTAssertNotNil(somesdk.serviceURL == "https://myhost.com/my/service2/base/url") // from TestVcapServices.json
+        } catch {
+            XCTFail("newInstance method failed: \(error)")
+        }
+    }
+    #endif
+
+    // MARK: includeExternalConfig enabled
+
+    // Test SDK initializers for a service that specifies `includeExternalConfig = true`
+
+    #if !os(Linux)
+    // Test normal init method
+    func testAnotherSDKInit() {
+        let authenticator = BasicAuthenticator(username: "username", password: "password")
+        let anothersdk = AnotherSDK(authenticator: authenticator)
+        XCTAssertNotNil(anothersdk)
+        XCTAssertNotNil(anothersdk.authenticator as? BasicAuthenticator)
+        XCTAssert(anothersdk.serviceURL == "http://cloud.ibm.com/anothersdk/v1")
+    }
+
+    #else
+    // Test init method without supplied authenticator
+    func testAnotherSDKInit() {
+        if ProcessInfo.processInfo.environment["VCAP_SERVICES"] == nil {
+            XCTFail("VCAP_SERVICES is not defined in the test environment")
+        }
+
+        do {
+            let anothersdk = try AnotherSDK()
+            XCTAssertNotNil(anothersdk)
+            XCTAssertNotNil(anothersdk.authenticator as? BasicAuthenticator)
+            XCTAssertNotNil(anothersdk.serviceURL == "https://myhost.com/my/service1/base/url") // from TestVcapServices.json
+        } catch {
+            XCTFail("init method failed: \(error)")
+        }
+    }
+
+    // Test init method with supplied authenticator
+    func testAnotherSDKInitWithAuthenticator() {
+        if ProcessInfo.processInfo.environment["VCAP_SERVICES"] == nil {
+            XCTFail("VCAP_SERVICES is not defined in the test environment")
+        }
+
+        do {
+            let authenticator = IAMAuthenticator(apiKey: "apikey")
+            let anothersdk = try AnotherSDK(authenticator: authenticator)
+            XCTAssertNotNil(anothersdk)
+            XCTAssertNotNil(anothersdk.authenticator as? IAMAuthenticator)
+            XCTAssertNotNil(anothersdk.serviceURL == "https://myhost.com/my/service1/base/url") // from TestVcapServices.json
+        } catch {
+            XCTFail("init method failed: \(error)")
+        }
+    }
+
+    // Test init method with specified service name
+    func testAnotherSDKInitWithServiceName() {
+        if ProcessInfo.processInfo.environment["VCAP_SERVICES"] == nil {
+            XCTFail("VCAP_SERVICES is not defined in the test environment")
+        }
+
+        do {
+            let anothersdk = try AnotherSDK(serviceName: "service2")
+            XCTAssertNotNil(anothersdk)
+            XCTAssertNotNil(anothersdk.authenticator as? IAMAuthenticator)
+            XCTAssertNotNil(anothersdk.serviceURL == "https://myhost.com/my/service2/base/url") // from TestVcapServices.json
+        } catch {
+            XCTFail("init method failed: \(error)")
+        }
+    }
+    #endif
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -11,4 +11,5 @@ XCTMain([
     testCase(MultiPartFormDataTests.allTests),
     testCase(CredentialUtilsTests.allTests),
     testCase(ConfigBasedAuthenticatorFactoryTests.allTests),
+    testCase(SDKInitializerTests.allTests),
 ])


### PR DESCRIPTION
This PR adds tests for the various flavors of init methods that are generated by the SDK generator.

The PR also includes a simple build fix to drop the unneeded `carthage bootstrap` step when building the carthage binaries.  This command throws an error that makes it look like the build failed.