### PR TITLE
Updated package specifications to prevent compile error

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.0
 
 /**
  * (C) Copyright IBM Corp. 2016, 2019.
@@ -20,6 +20,12 @@ import PackageDescription
 
 let package = Package(
     name: "IBMSwiftSDKCore",
+    platforms: [
+           .macOS(.v10_12),
+           .iOS(.v10),
+           .tvOS(.v10),
+           .watchOS(.v3)
+       ],
     products: [
         .library(name: "IBMSwiftSDKCore", targets: ["IBMSwiftSDKCore"]),
     ],

--- a/Tests/IBMSwiftSDKCoreTests/RestErrorTests.swift
+++ b/Tests/IBMSwiftSDKCoreTests/RestErrorTests.swift
@@ -31,6 +31,7 @@ class RestErrorTests: XCTestCase {
 
         guard case RestError.http(let statusCode, _, _) = httpError else {
             XCTFail("Expected RestError.http")
+            return
         }
         XCTAssertEqual(statusCode, testStatusCode)
     }
@@ -41,6 +42,7 @@ class RestErrorTests: XCTestCase {
 
         guard case RestError.http(_, let message, _) = httpError else {
             XCTFail("Expected RestError.http")
+            return
         }
         XCTAssertEqual(message, testMessage)
         XCTAssertEqual(httpError.errorDescription, testMessage)
@@ -57,6 +59,7 @@ class RestErrorTests: XCTestCase {
 
         guard case RestError.http(_, _, let metadata) = httpError else {
             XCTFail("Expected RestError.http")
+            return
         }
         XCTAssertEqual(metadata!["key0"] as? Int, 42)
         XCTAssertEqual(metadata!["key1"] as? Bool, true)


### PR DESCRIPTION
### Summary

1. 

When I tried to compile as a standalone swift package (without project files) before, I got compiler error in CredentialUtils.swift about: 

![error](https://user-images.githubusercontent.com/19404588/81852091-c735ab80-955a-11ea-8e15-1ecd37b727be.png)

To prevent this error I added package platform specifications. In order to do this I had to update swift-tools-version to 5.0

2.

Then I got compiler error in RestErrorTests.swift:

![error2](https://user-images.githubusercontent.com/19404588/81852402-40cd9980-955b-11ea-98a3-dcee8a6dccd7.png)

To prevent this error I added return statements

### Other Information
Xcode: Version 11.4.1 (11E503a)

Please check the version numbers if they fit. I used similar requirements to what I had found in the README.

The error occurred the first time as described in this issue:
https://github.com/watson-developer-cloud/swift-sdk/issues/1015

Best regards 
Benjamin 

Thanks for contributing to the IBM Cloud!