### PR TITLE
fix(cred-util): change swift attributes to preprocessor flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ jobs:
     - os: osx
       script: ./Scripts/travis/test-macOS.sh
       osx_image: xcode11
+    - os: osx
+      script: ./Scripts/travis/test-macOS.sh
+      osx_image: xcode12.3
     - stage: release new version
       script: ./Scripts/travis/new-release.sh
       os: osx

--- a/Sources/IBMSwiftSDKCore/Authentication/ConfigBasedAuthenticatorFactory.swift
+++ b/Sources/IBMSwiftSDKCore/Authentication/ConfigBasedAuthenticatorFactory.swift
@@ -34,10 +34,7 @@ public enum EnvironmentAuthenticatorType: String {
     case bearerToken = "bearertoken"
 }
 
-@available (iOS, unavailable, message: "ConfigBasedAuthenticatorFactory is currently available on Linux only.")
-@available (tvOS, unavailable, message: "ConfigBasedAuthenticatorFactory is currently available on Linux only.")
-@available (macOS, unavailable, message: "ConfigBasedAuthenticatorFactory is currently available on Linux only.")
-@available (watchOS, unavailable, message: "ConfigBasedAuthenticatorFactory is currently available on Linux only.")
+#if os(Linux)
 public struct ConfigBasedAuthenticatorFactory {
     static public func getAuthenticator(credentialPrefix: String) throws -> Authenticator {
         guard let environmentVariables = CredentialUtils.getEnvironmentVariables(credentialPrefix: credentialPrefix) else {
@@ -123,3 +120,4 @@ public struct ConfigBasedAuthenticatorFactory {
         return cp4dAuthenticator
     }
 }
+#endif

--- a/Sources/IBMSwiftSDKCore/CredentialUtils.swift
+++ b/Sources/IBMSwiftSDKCore/CredentialUtils.swift
@@ -30,12 +30,8 @@ public enum EnvironmentAuthenticatorVariable: String {
     case disableSSL = "auth_disable_ssl"
 }
 
-@available (iOS, unavailable, message: "ConfigBasedAuthenticatorFactory is currently available on Linux only.")
-@available (tvOS, unavailable, message: "ConfigBasedAuthenticatorFactory is currently available on Linux only.")
-@available (macOS, unavailable, message: "ConfigBasedAuthenticatorFactory is currently available on Linux only.")
-@available (watchOS, unavailable, message: "ConfigBasedAuthenticatorFactory is currently available on Linux only.")
+#if os(Linux)
 public struct CredentialUtils {
-    @available(iOS 9.0, *)
     static public func getEnvironmentVariables(credentialPrefix: String) -> [String: String]? {
         let formattedCredentialPrefix: String = credentialPrefix.uppercased()
 
@@ -70,7 +66,6 @@ public struct CredentialUtils {
         return nil
     }
 
-    @available(iOS 9.0, *)
     static public func getServiceURL(credentialPrefix: String) -> String? {
         guard let credentials = CredentialUtils.getEnvironmentVariables(credentialPrefix: credentialPrefix) else {
             return nil
@@ -161,3 +156,4 @@ public struct CredentialUtils {
         return nil
     }
 }
+#endif

--- a/Tests/IBMSwiftSDKCoreTests/RestErrorTests.swift
+++ b/Tests/IBMSwiftSDKCoreTests/RestErrorTests.swift
@@ -31,6 +31,7 @@ class RestErrorTests: XCTestCase {
 
         guard case RestError.http(let statusCode, _, _) = httpError else {
             XCTFail("Expected RestError.http")
+            return
         }
         XCTAssertEqual(statusCode, testStatusCode)
     }
@@ -41,6 +42,7 @@ class RestErrorTests: XCTestCase {
 
         guard case RestError.http(_, let message, _) = httpError else {
             XCTFail("Expected RestError.http")
+            return
         }
         XCTAssertEqual(message, testMessage)
         XCTAssertEqual(httpError.errorDescription, testMessage)
@@ -57,6 +59,7 @@ class RestErrorTests: XCTestCase {
 
         guard case RestError.http(_, _, let metadata) = httpError else {
             XCTFail("Expected RestError.http")
+            return
         }
         XCTAssertEqual(metadata!["key0"] as? Int, 42)
         XCTAssertEqual(metadata!["key1"] as? Bool, true)


### PR DESCRIPTION
I changed some swift attributes to Linux preprocessor flags to fix errors occurring with Carthage installs on Xcode 11