### PR TITLE
ci(cocoapods): allow warnings

### DIFF
--- a/Scripts/travis/deploy-to-cocoapods.sh
+++ b/Scripts/travis/deploy-to-cocoapods.sh
@@ -1,4 +1,4 @@
 set -e
 
 git pull # Needed to get the new version created by semantic-release
-pod trunk push "IBMSwiftSDKCore.podspec"
+pod trunk push "IBMSwiftSDKCore.podspec" --allow-warnings


### PR DESCRIPTION
### Summary

This PR allows warnings when pushing to cocoapods.