### PR TITLE
fix(build): main migration

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -34,7 +34,7 @@ If you want to contribute to the repository, here's a quick guide:
     * Create minimal diffs - disable on save actions like reformat source code or organize imports. If you feel the source code should be reformatted create a separate PR for this change.
     * Check for unnecessary whitespace with `git diff --check` before committing.
   3. Verify that tests pass successfully.
-  4. Push to your fork and submit a pull request to the **master** branch.
+  4. Push to your fork and submit a pull request to the **main** branch.
 
 ## Additional Resources
 + [General GitHub documentation](https://help.github.com/)

--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,5 @@
 {
-  "branch": "master",
+  "branch": "main",
   "verifyConditions": [],
   "tagFormat": "${version}",
   "prepare": [

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,9 @@ jobs:
       script: ./Scripts/travis/new-release.sh
       os: osx
       osx_image: xcode11
-      if: branch = master AND type = push AND fork = false
+      if: branch = main AND type = push AND fork = false
     - stage: deploy to cocoapods
       script: ./Scripts/travis/deploy-to-cocoapods.sh
       os: osx
       osx_image: xcode11
-      if: branch = master AND type = push AND fork = false
+      if: branch = main AND type = push AND fork = false

--- a/README.md
+++ b/README.md
@@ -79,11 +79,11 @@ dependencies: [
 
 ## Contributing
 
-We would love any and all help! If you would like to contribute, please read our [CONTRIBUTING](https://github.com/IBM/swift-sdk-core/blob/master/.github/CONTRIBUTING.md) documentation with information on getting started.
+We would love any and all help! If you would like to contribute, please read our [CONTRIBUTING](https://github.com/IBM/swift-sdk-core/blob/main/.github/CONTRIBUTING.md) documentation with information on getting started.
 
 ## License
 
 This library is licensed under Apache 2.0. Full license text is
-available in [LICENSE](https://github.com/IBM/swift-sdk-core/blob/master/LICENSE).
+available in [LICENSE](https://github.com/IBM/swift-sdk-core/blob/main/LICENSE).
 
 This SDK is intended for use with an Apple iOS product and intended to be used in conjunction with officially licensed Apple development tools.


### PR DESCRIPTION
This PR updates links and automation to support the renaming of the default branch from `master` to `main`.